### PR TITLE
feat: task level submissions and results

### DIFF
--- a/unicon_backend/app.py
+++ b/unicon_backend/app.py
@@ -15,7 +15,7 @@ from unicon_backend.constants import FRONTEND_URL, RABBITMQ_URL, sql_engine
 from unicon_backend.dependencies.auth import get_current_user
 from unicon_backend.dependencies.session import get_session
 from unicon_backend.evaluator.contest import Definition, ExpectedAnswers, UserInputs
-from unicon_backend.evaluator.tasks.base import TaskEvalStatus
+from unicon_backend.evaluator.tasks.base import TaskEvalResult, TaskEvalStatus
 from unicon_backend.logger import setup_rich_logger
 from unicon_backend.models import (
     DefinitionORM,
@@ -59,7 +59,13 @@ async def listen_to_mq():
                     )
                     if not task_result:
                         return
-                    task_result.other_fields = body["result"]
+
+                    task_result.other_fields = TaskEvalResult(
+                        task_id=task_result.task_id,
+                        status=TaskEvalStatus.SUCCESS,
+                        result=body["result"],
+                    ).model_dump(mode="json")
+
                     session.add(task_result)
                     session.commit()
 
@@ -137,63 +143,70 @@ def submit(
     session: Annotated[Session, Depends(get_session)],
     task_id: int | None = None,
 ):
-    definition_orm = session.scalar(
+    definition_orm: DefinitionORM | None = session.scalar(
         select(DefinitionORM)
         .where(DefinitionORM.id == id)
         .options(selectinload(DefinitionORM.tasks))
     )
 
-    if not definition_orm:
-        raise HTTPException(HTTPStatus.NOT_FOUND)
+    if definition_orm is None:
+        raise HTTPException(HTTPStatus.NOT_FOUND, "Contest definition not found")
 
-    def convert_orm_to_schemas(definiton_orm: DefinitionORM):
-        tasks: list[dict] = [
-            {
-                "id": task_orm.id,
-                "type": task_orm.type,
-                "autograde": task_orm.autograde,
-                **task_orm.other_fields,
-            }
-            for task_orm in definiton_orm.tasks
-        ]
+    definition: Definition = Definition.model_validate(
+        {
+            "name": definition_orm.name,
+            "description": definition_orm.description,
+            "tasks": [
+                {
+                    "id": task_orm.id,
+                    "type": task_orm.type,
+                    "autograde": task_orm.autograde,
+                    **task_orm.other_fields,
+                }
+                for task_orm in definition_orm.tasks
+            ],
+        }
+    )
 
-        return Definition.model_validate(
-            {"name": definiton_orm.name, "description": definiton_orm.description, "tasks": tasks}
-        )
+    task_results: list[TaskEvalResult] = definition.run(
+        submission.user_inputs, submission.expected_answers, task_id
+    )
+    has_pending_tasks: bool = any(
+        task_result.status == TaskEvalStatus.PENDING for task_result in task_results
+    )
 
-    definition = convert_orm_to_schemas(definition_orm)
+    submission_orm = SubmissionORM(
+        definition_id=id,
+        status=SubmissionStatus.Pending if has_pending_tasks else SubmissionStatus.Ok,
+        task_results=[
+            TaskResultORM(
+                definition_id=id,
+                task_id=task_result.task_id,
+                task_submission_id=task_result.result
+                if task_result.status == TaskEvalStatus.PENDING
+                else None,
+                other_fields=task_result.model_dump(mode="json"),
+            )
+            for task_result in task_results
+        ],
+        other_fields={},
+    )
 
-    result = definition.run(submission.user_inputs, submission.expected_answers, task_id)
-    pending = any(task.result.status == TaskEvalStatus.PENDING for task in result)
-    status = SubmissionStatus.Pending if pending else SubmissionStatus.Ok
-
-    submission_orm = SubmissionORM(definition_id=id, status=status, other_fields={})
-    task_results = [
-        TaskResultORM(
-            other_fields=task.model_dump(mode="json"),
-            task_submission_id=task.result.result
-            if task.result.status == TaskEvalStatus.PENDING
-            else None,
-        )
-        for task in result
-    ]
-    submission_orm.task_results = task_results
     session.add(submission_orm)
     session.commit()
     session.refresh(submission_orm)
+
     return submission_orm.task_results
 
 
-@app.get("/submission/{id}")
+@app.get("/submission/{id}/result")
 def get_submission(
     id: int,
     _user: Annotated[User, Depends(get_current_user)],
     session: Annotated[Session, Depends(get_session)],
+    task_id: int | None = None,
 ):
-    submission = session.scalar(
-        select(SubmissionORM)
-        .where(SubmissionORM.id == id)
-        .options(selectinload(SubmissionORM.task_results))
-    )
-
-    return submission
+    query = select(TaskResultORM).join(SubmissionORM).where(SubmissionORM.id == id)
+    if task_id is not None:
+        query = query.where(TaskResultORM.task_id == task_id)
+    return session.execute(query).scalars().all()

--- a/unicon_backend/app.py
+++ b/unicon_backend/app.py
@@ -135,6 +135,7 @@ def submit(
     submission: Submission,
     _user: Annotated[User, Depends(get_current_user)],
     session: Annotated[Session, Depends(get_session)],
+    task_id: int | None = None,
 ):
     definition_orm = session.scalar(
         select(DefinitionORM)
@@ -162,7 +163,7 @@ def submit(
 
     definition = convert_orm_to_schemas(definition_orm)
 
-    result = definition.run(submission.user_inputs, submission.expected_answers)
+    result = definition.run(submission.user_inputs, submission.expected_answers, task_id)
     pending = any(task.result.status == TaskEvalStatus.PENDING for task in result)
     status = SubmissionStatus.Pending if pending else SubmissionStatus.Ok
 

--- a/unicon_backend/evaluator/tasks/base.py
+++ b/unicon_backend/evaluator/tasks/base.py
@@ -5,11 +5,17 @@ from typing import Any, Generic, TypeVar
 from pydantic import BaseModel
 
 from unicon_backend.lib.common import CustomBaseModel
-from unicon_backend.models.contest import TaskType
 
 TaskUserInput = TypeVar("TaskUserInput")
 TaskExpectedAnswer = TypeVar("TaskExpectedAnswer")
 TaskResult = TypeVar("TaskResult")
+
+
+class TaskType(str, Enum):
+    MULTIPLE_CHOICE = "MULTIPLE_CHOICE_TASK"
+    MULTIPLE_RESPONSE = "MULTIPLE_RESPONSE_TASK"
+    SHORT_ANSWER = "SHORT_ANSWER_TASK"
+    PROGRAMMING = "PROGRAMMING_TASK"
 
 
 class TaskEvalStatus(str, Enum):

--- a/unicon_backend/evaluator/tasks/base.py
+++ b/unicon_backend/evaluator/tasks/base.py
@@ -20,6 +20,7 @@ class TaskEvalStatus(str, Enum):
 
 
 class TaskEvalResult(BaseModel, Generic[TaskResult]):
+    task_id: int
     status: TaskEvalStatus
     result: TaskResult | None
     error: str | None = None

--- a/unicon_backend/evaluator/tasks/multiple_choice.py
+++ b/unicon_backend/evaluator/tasks/multiple_choice.py
@@ -10,7 +10,9 @@ class MultipleChoiceTask(Task[int, bool, int]):
     choices: list[str]
 
     def run(self, user_input: int, expected_answer: int) -> TaskEvalResult[bool]:
-        return TaskEvalResult(status=TaskEvalStatus.SUCCESS, result=user_input == expected_answer)
+        return TaskEvalResult(
+            task_id=self.id, status=TaskEvalStatus.SUCCESS, result=user_input == expected_answer
+        )
 
     def validate_user_input(self, user_input: Any) -> int:
         return RootModel[int].model_validate(user_input).root
@@ -39,6 +41,7 @@ class MultipleResponseTask(Task[set[int], MultipleResponseTaskResult, set[int]])
         self, user_input: set[int], expected_answer: set[int]
     ) -> TaskEvalResult[MultipleResponseTaskResult]:
         return TaskEvalResult(
+            task_id=self.id,
             status=TaskEvalStatus.SUCCESS,
             result=MultipleResponseTaskResult(
                 correct_choices=user_input & expected_answer,

--- a/unicon_backend/evaluator/tasks/multiple_choice.py
+++ b/unicon_backend/evaluator/tasks/multiple_choice.py
@@ -5,13 +5,15 @@ from pydantic import BaseModel, RootModel
 from unicon_backend.evaluator.tasks.base import Task, TaskEvalResult, TaskEvalStatus
 
 
-class MultipleChoiceTask(Task[int, bool, int]):
+class MultipleChoiceTask(Task[int, RootModel[bool], int]):
     question: str
     choices: list[str]
 
-    def run(self, user_input: int, expected_answer: int) -> TaskEvalResult[bool]:
+    def run(self, user_input: int, expected_answer: int) -> TaskEvalResult[RootModel[bool]]:
         return TaskEvalResult(
-            task_id=self.id, status=TaskEvalStatus.SUCCESS, result=user_input == expected_answer
+            task_id=self.id,
+            status=TaskEvalStatus.SUCCESS,
+            result=RootModel[bool](user_input == expected_answer),
         )
 
     def validate_user_input(self, user_input: Any) -> int:

--- a/unicon_backend/evaluator/tasks/programming.py
+++ b/unicon_backend/evaluator/tasks/programming.py
@@ -125,7 +125,7 @@ class ProgrammingTask(Task[list[File], str, list[ProgrammingTaskExpectedAnswer]]
 
         # TODO: check output and handle pending testcases
         # TODO: maybe move submission id else where
-        return TaskEvalResult(status=TaskEvalStatus.PENDING, result=submission_id)
+        return TaskEvalResult(task_id=self.id, status=TaskEvalStatus.PENDING, result=submission_id)
 
     def validate_user_input(self, user_input: Any) -> list[File]:
         return RootModel[list[File]].model_validate(user_input).root

--- a/unicon_backend/evaluator/tasks/short_answer.py
+++ b/unicon_backend/evaluator/tasks/short_answer.py
@@ -14,6 +14,7 @@ class ShortAnswerTask(Task[str, bool, str]):
             return TaskEvalResult(task_id=self.id, status=TaskEvalStatus.SKIPPED, result=None)
 
         return TaskEvalResult(
+            id=self.id,
             status=TaskEvalStatus.SUCCESS,
             result=(expected_answer is not None) and (expected_answer == user_input),
         )

--- a/unicon_backend/evaluator/tasks/short_answer.py
+++ b/unicon_backend/evaluator/tasks/short_answer.py
@@ -5,18 +5,20 @@ from pydantic import RootModel
 from unicon_backend.evaluator.tasks.base import Task, TaskEvalResult, TaskEvalStatus
 
 
-class ShortAnswerTask(Task[str, bool, str]):
+class ShortAnswerTask(Task[str, RootModel[bool], str]):
     question: str
     autograde: bool = False
 
-    def run(self, user_input: str, expected_answer: str) -> TaskEvalResult[bool]:
+    def run(self, user_input: str, expected_answer: str) -> TaskEvalResult[RootModel[bool]]:
         if self.autograde is False:
             return TaskEvalResult(task_id=self.id, status=TaskEvalStatus.SKIPPED, result=None)
 
         return TaskEvalResult(
             task_id=self.id,
             status=TaskEvalStatus.SUCCESS,
-            result=(expected_answer is not None) and (expected_answer == user_input),
+            result=RootModel[bool](
+                (expected_answer is not None) and (expected_answer == user_input)
+            ),
         )
 
     def validate_user_input(self, user_input: Any) -> str:

--- a/unicon_backend/evaluator/tasks/short_answer.py
+++ b/unicon_backend/evaluator/tasks/short_answer.py
@@ -11,7 +11,7 @@ class ShortAnswerTask(Task[str, bool, str]):
 
     def run(self, user_input: str, expected_answer: str) -> TaskEvalResult[bool]:
         if self.autograde is False:
-            return TaskEvalResult(status=TaskEvalStatus.SKIPPED, result=None)
+            return TaskEvalResult(task_id=self.id, status=TaskEvalStatus.SKIPPED, result=None)
 
         return TaskEvalResult(
             status=TaskEvalStatus.SUCCESS,

--- a/unicon_backend/evaluator/tasks/short_answer.py
+++ b/unicon_backend/evaluator/tasks/short_answer.py
@@ -14,7 +14,7 @@ class ShortAnswerTask(Task[str, bool, str]):
             return TaskEvalResult(task_id=self.id, status=TaskEvalStatus.SKIPPED, result=None)
 
         return TaskEvalResult(
-            id=self.id,
+            task_id=self.id,
             status=TaskEvalStatus.SUCCESS,
             result=(expected_answer is not None) and (expected_answer == user_input),
         )

--- a/unicon_backend/migrations/versions/34d40a4b8879_add_definition_and_task_table.py
+++ b/unicon_backend/migrations/versions/34d40a4b8879_add_definition_and_task_table.py
@@ -39,10 +39,7 @@ def upgrade() -> None:
         sa.Column("autograde", sa.Boolean(), nullable=False),
         sa.Column("other_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column("definition_id", sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["definition_id"],
-            ["definition.id"],
-        ),
+        sa.ForeignKeyConstraint(["definition_id"], ["definition.id"]),
         sa.PrimaryKeyConstraint("id", "definition_id"),
     )
     # ### end Alembic commands ###

--- a/unicon_backend/migrations/versions/34d40a4b8879_add_definition_and_task_table.py
+++ b/unicon_backend/migrations/versions/34d40a4b8879_add_definition_and_task_table.py
@@ -19,7 +19,7 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 task_type_enum = sa.Enum(
-    "MULTIPLE_CHOICE", "MULTIPLE_RESPONSE", "SHORT_ANSWER", "PROGRAMMING", name="tasktype"
+    "MULTIPLE_CHOICE", "MULTIPLE_RESPONSE", "SHORT_ANSWER", "PROGRAMMING", name="task_type"
 )
 
 

--- a/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
+++ b/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
@@ -19,6 +19,7 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 submission_status_enum = sa.Enum("Pending", "Ok", name="submissionstatus")
+task_result_status_enum = sa.Enum("SUCCESS", "PENDING", "SKIPPED", "FAILED", name="taskevalstatus")
 
 
 def upgrade() -> None:
@@ -38,12 +39,14 @@ def upgrade() -> None:
         sa.Column("submission_id", sa.Integer(), nullable=False),
         sa.Column("definition_id", sa.Integer(), nullable=True),
         sa.Column("task_id", sa.Integer(), nullable=True),
-        sa.Column("task_submission_id", sa.String(), nullable=True),
-        sa.Column("other_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("job_id", sa.String(), nullable=True),
+        sa.Column("status", task_result_status_enum, nullable=False),
+        sa.Column("result", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("error", sa.String(), nullable=True),
         sa.PrimaryKeyConstraint("id"),
         sa.ForeignKeyConstraint(["submission_id"], ["submission.id"]),
-        sa.UniqueConstraint("task_submission_id"),
         sa.ForeignKeyConstraint(["definition_id", "task_id"], ["task.definition_id", "task.id"]),
+        sa.UniqueConstraint("job_id"),
     )
     # ### end Alembic commands ###
 
@@ -54,4 +57,5 @@ def downgrade() -> None:
     op.drop_table("submission")
 
     submission_status_enum.drop(op.get_bind())
+    task_result_status_enum.drop(op.get_bind())
     # ### end Alembic commands ###

--- a/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
+++ b/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
@@ -29,24 +29,21 @@ def upgrade() -> None:
         sa.Column("status", submission_status_enum, nullable=False),
         sa.Column("definition_id", sa.Integer(), nullable=True),
         sa.Column("other_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["definition_id"],
-            ["definition.id"],
-        ),
+        sa.ForeignKeyConstraint(["definition_id"], ["definition.id"]),
         sa.PrimaryKeyConstraint("id"),
     )
     op.create_table(
         "task_result",
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("submission_id", sa.Integer(), nullable=False),
+        sa.Column("definition_id", sa.Integer(), nullable=True),
+        sa.Column("task_id", sa.Integer(), nullable=True),
         sa.Column("task_submission_id", sa.String(), nullable=True),
         sa.Column("other_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["submission_id"],
-            ["submission.id"],
-        ),
         sa.PrimaryKeyConstraint("id"),
+        sa.ForeignKeyConstraint(["submission_id"], ["submission.id"]),
         sa.UniqueConstraint("task_submission_id"),
+        sa.ForeignKeyConstraint(["definition_id", "task_id"], ["task.definition_id", "task.id"]),
     )
     # ### end Alembic commands ###
 

--- a/unicon_backend/models/contest.py
+++ b/unicon_backend/models/contest.py
@@ -56,8 +56,12 @@ class TaskResultORM(Base):
     definition_id: Mapped[int]
     task_id: Mapped[int]
 
-    task_submission_id: Mapped[str | None] = mapped_column(unique=True, nullable=True)
-    other_fields: Mapped[dict] = mapped_column(JSONB)
+    # NOTE: Unique identifier for a worker job that evaluates the task
+    job_id: Mapped[str | None] = mapped_column(unique=True, nullable=True)
+
+    status: Mapped[TaskEvalStatus]
+    result: Mapped[dict] = mapped_column(JSONB)
+    error: Mapped[str | None] = mapped_column(nullable=True)
 
     submission: Mapped[SubmissionORM] = relationship(back_populates="task_results")
 

--- a/unicon_backend/models/contest.py
+++ b/unicon_backend/models/contest.py
@@ -4,14 +4,8 @@ from sqlalchemy import ForeignKey, ForeignKeyConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from unicon_backend.evaluator.tasks.base import TaskEvalStatus, TaskType
 from unicon_backend.models.base import Base
-
-
-class TaskType(str, Enum):
-    MULTIPLE_CHOICE = "MULTIPLE_CHOICE_TASK"
-    MULTIPLE_RESPONSE = "MULTIPLE_RESPONSE_TASK"
-    SHORT_ANSWER = "SHORT_ANSWER_TASK"
-    PROGRAMMING = "PROGRAMMING_TASK"
 
 
 class DefinitionORM(Base):

--- a/unicon_backend/models/contest.py
+++ b/unicon_backend/models/contest.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from sqlalchemy import ForeignKey
+from sqlalchemy import ForeignKey, ForeignKeyConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -59,8 +59,14 @@ class TaskResultORM(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     submission_id: Mapped[int] = mapped_column(ForeignKey("submission.id"))
+    definition_id: Mapped[int]
+    task_id: Mapped[int]
 
     task_submission_id: Mapped[str | None] = mapped_column(unique=True, nullable=True)
     other_fields: Mapped[dict] = mapped_column(JSONB)
 
     submission: Mapped[SubmissionORM] = relationship(back_populates="task_results")
+
+    __table_args__ = (
+        ForeignKeyConstraint(["definition_id", "task_id"], [TaskORM.definition_id, TaskORM.id]),
+    )


### PR DESCRIPTION
# Description

- Support for Task level submissions and results
- Renamed `TaskResult::task_submission_id` to `TaskResult::job_id` to make it explicit that the `id` is for a worker job
- Flattened `TaskResult` data model in database - instead of enclosing all data in a JSON blob (as a quick hack previously)

<img width="223" alt="image" src="https://github.com/user-attachments/assets/6687f0e1-00b3-4fff-9f1b-f24c7bdf11c2">

