### PR TITLE
feat: add timestamps to `task_results` and `submissions`

### DIFF
--- a/unicon_backend/app.py
+++ b/unicon_backend/app.py
@@ -29,7 +29,7 @@ async def lifespan(app: FastAPI):
     task_publisher.stop()
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(title="Unicon 🦄 Backend", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
+++ b/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
@@ -29,6 +29,9 @@ def upgrade() -> None:
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("status", submission_status_enum, nullable=False),
         sa.Column("definition_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "submitted_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False
+        ),
         sa.Column("other_fields", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.ForeignKeyConstraint(["definition_id"], ["definition.id"]),
         sa.PrimaryKeyConstraint("id"),

--- a/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
+++ b/unicon_backend/migrations/versions/9f847be1183f_add_submission_and_task_table.py
@@ -39,6 +39,8 @@ def upgrade() -> None:
         sa.Column("submission_id", sa.Integer(), nullable=False),
         sa.Column("definition_id", sa.Integer(), nullable=True),
         sa.Column("task_id", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
         sa.Column("job_id", sa.String(), nullable=True),
         sa.Column("status", task_result_status_enum, nullable=False),
         sa.Column("result", postgresql.JSONB(astext_type=sa.Text()), nullable=True),

--- a/unicon_backend/models/contest.py
+++ b/unicon_backend/models/contest.py
@@ -55,6 +55,9 @@ class SubmissionORM(Base):
     id: Mapped[int] = mapped_column(primary_key=True)
     definition_id = mapped_column(sa.ForeignKey("definition.id"))
     status: Mapped[SubmissionStatus]
+    submitted_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), server_default=sa.func.now()
+    )
 
     # TODO: split this to one more table
     other_fields: Mapped[dict] = mapped_column(JSONB)

--- a/unicon_backend/models/contest.py
+++ b/unicon_backend/models/contest.py
@@ -1,6 +1,7 @@
+from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import ForeignKey, ForeignKeyConstraint
+import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -38,7 +39,7 @@ class TaskORM(Base):
     type: Mapped[TaskType]
     autograde: Mapped[bool]
     other_fields: Mapped[dict] = mapped_column(JSONB)
-    definition_id: Mapped[int] = mapped_column(ForeignKey("definition.id"), primary_key=True)
+    definition_id: Mapped[int] = mapped_column(sa.ForeignKey("definition.id"), primary_key=True)
 
     definition: Mapped[DefinitionORM] = relationship(back_populates="tasks")
 
@@ -52,7 +53,7 @@ class SubmissionORM(Base):
     __tablename__ = "submission"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    definition_id = mapped_column(ForeignKey("definition.id"))
+    definition_id = mapped_column(sa.ForeignKey("definition.id"))
     status: Mapped[SubmissionStatus]
 
     # TODO: split this to one more table
@@ -65,9 +66,14 @@ class TaskResultORM(Base):
     __tablename__ = "task_result"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    submission_id: Mapped[int] = mapped_column(ForeignKey("submission.id"))
+    submission_id: Mapped[int] = mapped_column(sa.ForeignKey("submission.id"))
     definition_id: Mapped[int]
     task_id: Mapped[int]
+
+    started_at: Mapped[datetime] = mapped_column(
+        sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(sa.DateTime(timezone=True), nullable=True)
 
     # NOTE: Unique identifier for a worker job that evaluates the task
     job_id: Mapped[str | None] = mapped_column(unique=True, nullable=True)
@@ -79,5 +85,5 @@ class TaskResultORM(Base):
     submission: Mapped[SubmissionORM] = relationship(back_populates="task_results")
 
     __table_args__ = (
-        ForeignKeyConstraint(["definition_id", "task_id"], [TaskORM.definition_id, TaskORM.id]),
+        sa.ForeignKeyConstraint(["definition_id", "task_id"], [TaskORM.definition_id, TaskORM.id]),
     )

--- a/unicon_backend/workers.py
+++ b/unicon_backend/workers.py
@@ -31,6 +31,7 @@ class TaskResultsConsumer(AsyncConsumer):
             )
             if task_result is not None:
                 task_result.status = TaskEvalStatus.SUCCESS
+                task_result.completed_at = sa.func.now()
                 task_result.result = body_json["result"]
 
                 session.add(task_result)


### PR DESCRIPTION
# Description
This PR adds timestamp columns to `task_results` and `submission` database tables. This is primarily for debugging and monitoring, but it also gives us an idea of the overhead sending a remote job to the runner.

- `started_at` in the `task_results` table represents the timestamp the job was **published** to the queue and not when the runner **consumed** the job