### PR TITLE
feat: add object access node

### DIFF
--- a/unicon_backend/data/breakthrough_definition.json
+++ b/unicon_backend/data/breakthrough_definition.json
@@ -32,7 +32,7 @@
               "from_node_id": 2,
               "from_socket_id": "DATA.OUT",
               "to_node_id": 3,
-              "to_socket_id": "DATA"
+              "to_socket_id": "DATA.IN"
             },
             {
               "id": 3,
@@ -297,7 +297,7 @@
                   "id": "CONTROL.IN"
                 },
                 {
-                  "id": "DATA"
+                  "id": "DATA.IN"
                 }
               ],
               "outputs": [

--- a/unicon_backend/data/breakthrough_definition.json
+++ b/unicon_backend/data/breakthrough_definition.json
@@ -1,0 +1,575 @@
+{
+  "name": "Test",
+  "description": "",
+  "tasks": [
+    {
+      "id": 1,
+      "type": "PROGRAMMING_TASK",
+      "question": "Breakthrough Match",
+      "environment": {
+        "language": "PYTHON",
+        "extra_options": {
+          "version": "3.12",
+          "requirements": "timeout_decorator"
+        },
+        "time_limit": 100,
+        "memory_limit": 500
+      },
+      "required_inputs": [],
+      "testcases": [
+        {
+          "id": 1,
+          "edges": [
+            {
+              "id": 1,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 2,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 2,
+              "from_node_id": 2,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 3,
+              "to_socket_id": "DATA"
+            },
+            {
+              "id": 3,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 4,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 4,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 4,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 5,
+              "from_node_id": 4,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 5,
+              "to_socket_id": "CONTROL.IN.PREDICATE"
+            },
+            {
+              "id": 6,
+              "from_node_id": 5,
+              "from_socket_id": "CONTROL.OUT.BODY",
+              "to_node_id": 6,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 7,
+              "from_node_id": 14,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 6,
+              "to_socket_id": "CONTROL.IN.PREDICATE"
+            },
+            {
+              "id": 8,
+              "from_node_id": 6,
+              "from_socket_id": "CONTROL.OUT.IF",
+              "to_node_id": 7,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 9,
+              "from_node_id": 0,
+              "from_socket_id": "DATA.OUT.FILE.0",
+              "to_node_id": 7,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 10,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 7,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 11,
+              "from_node_id": 7,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 8,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 12,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 8,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 13,
+              "from_node_id": 2,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 8,
+              "to_socket_id": "DATA.IN.ARG.0.STATE"
+            },
+            {
+              "id": 14,
+              "from_node_id": 7,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 8,
+              "to_socket_id": "DATA.IN.ARG.1.MOVE"
+            },
+            {
+              "id": 15,
+              "from_node_id": 6,
+              "from_socket_id": "CONTROL.OUT.ELSE",
+              "to_node_id": 9,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 16,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 9,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 17,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 9,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 18,
+              "from_node_id": 9,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 10,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 19,
+              "from_node_id": 0,
+              "from_socket_id": "DATA.OUT.FILE.1",
+              "to_node_id": 10,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 20,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 10,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 21,
+              "from_node_id": 10,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 11,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 22,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 11,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 23,
+              "from_node_id": 2,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 11,
+              "to_socket_id": "DATA.IN.ARG.0.STATE"
+            },
+            {
+              "id": 24,
+              "from_node_id": 10,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 11,
+              "to_socket_id": "DATA.IN.ARG.1.MOVE"
+            },
+            {
+              "id": 25,
+              "from_node_id": 11,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 12,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 26,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 12,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 27,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 12,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 28,
+              "from_node_id": 5,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 13,
+              "to_socket_id": "CONTROL.IN"
+            },
+            {
+              "id": 29,
+              "from_node_id": 2,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 13,
+              "to_socket_id": "DATA.STATE"
+            },
+            {
+              "id": 30,
+              "from_node_id": 1,
+              "from_socket_id": "DATA.OUT.FILE",
+              "to_node_id": 14,
+              "to_socket_id": "DATA.IN.FILE"
+            },
+            {
+              "id": 31,
+              "from_node_id": 3,
+              "from_socket_id": "DATA.OUT",
+              "to_node_id": 14,
+              "to_socket_id": "DATA.IN.ARG.0.BOARD"
+            },
+            {
+              "id": 32,
+              "from_node_id": 3,
+              "from_socket_id": "CONTROL.OUT",
+              "to_node_id": 5,
+              "to_socket_id": "CONTROL.IN"
+            }
+          ],
+          "nodes": [
+            {
+              "id": 1,
+              "type": "INPUT_STEP",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "CONTROL.OUT"
+                },
+                {
+                  "id": "DATA.OUT.FILE",
+                  "data": {
+                    "file_name": "utils.py",
+                    "content": "import copy\nimport multiprocessing\nimport sys\nimport os\nimport time\nimport timeout_decorator\nimport functools\nfrom threading import Thread\n\n# board row and column -> these are constant\nROW, COL = 6, 6\n\n\n# generates initial state\ndef generate_init_state():\n    state = [\n        ['B'] * COL,\n        ['B'] * COL,  # 2 black rows\n        ['_'] * COL,\n        ['_'] * COL,  # 2 empty rows\n        ['W'] * COL,\n        ['W'] * COL,  # 2 white rows\n    ]\n    return {'board': state, 'move': 'B'}\n\n\n# prints board\ndef print_state(board):\n    horizontal_rule = '+' + ('-' * 5 + '+') * COL\n    for i in range(len(board)):\n        print(horizontal_rule)\n        print(\n            '|  '\n            + '  |  '.join(' ' if board[i][j] == '_' else board[i][j] for j in range(COL))\n            + '  |'\n        )\n    print(horizontal_rule)\n\n\n# inverts board by modifying board state, or returning a new board with updated board state\ndef invert_board(curr_board, in_place=True):\n    '''Inverts the board by modifying existing values if in_place is set to True, or creating a new board with updated values if in_place is set to False'''\n    board = curr_board\n    if not in_place:\n        board = copy.deepcopy(curr_board)\n    board.reverse()\n    for i in range(len(board)):\n        for j in range(len(board[i])):\n            if board[i][j] == 'W':\n                board[i][j] = 'B'\n            elif board[i][j] == 'B':\n                board[i][j] = 'W'\n    return board\n\n\n# checks if a move made for black is valid or not. Move source: from_ [row, col], move destination: to_ [row, col]\ndef is_valid_move(board, from_, to_):\n    if board[from_[0]][from_[1]] != 'B':  # if move not made for black\n        return False\n    elif (to_[0] < 0 or to_[0] >= ROW) or (\n        to_[1] < 0 or to_[1] >= COL\n    ):  # if move takes pawn outside the board\n        return False\n    elif to_[0] != (from_[0] + 1):  # if move takes more than one step forward\n        return False\n    elif to_[1] > (from_[1] + 1) or to_[1] < (\n        from_[1] - 1\n    ):  # if move takes beyond left/ right diagonal\n        return False\n    elif (\n        to_[1] == from_[1] and board[to_[0]][to_[1]] != '_'\n    ):  # if pawn to the front, but still move forward\n        return False\n    elif ((to_[1] == from_[1] + 1) or (to_[1] == from_[1] - 1)) and board[to_[0]][\n        to_[1]\n    ] == 'B':  # if black pawn to the diagonal or front, but still move forward\n        return False\n    else:\n        return True\n\n\n# generates the first available valid move for black\ndef generate_rand_move(board):\n    from_, to_ = [0, 0], [0, 0]\n    for i in range(len(board)):\n        for j in range(len(board[i])):\n            if board[i][j] == 'B':\n                from_[0], from_[1] = i, j\n                to_[0] = from_[0] + 1\n                to_[1] = from_[1]\n                if is_valid_move(board, from_, to_):\n                    return from_, to_\n                to_[1] = from_[1] + 1\n                if is_valid_move(board, from_, to_):\n                    return from_, to_\n                to_[1] = from_[1] - 1\n                if is_valid_move(board, from_, to_):\n                    return from_, to_\n\n\n# makes a move effective on the board by modifying board state, or returning a new board with updated board state\ndef state_change_modified(state, move, in_place=True):\n    curr_board = state['board']\n\n    from_, to_ = move\n    '''Updates the board configuration by modifying existing values if in_place is set to True, or creating a new board with updated values if in_place is set to False'''\n    board = curr_board\n    if not in_place:\n        board = copy.deepcopy(curr_board)\n    if is_valid_move(board, from_, to_):\n        board[from_[0]][from_[1]] = '_'\n        board[to_[0]][to_[1]] = 'B'\n\n    state['board'] = curr_board\n    state['move'] = 'W' if state['move'] == 'B' else 'B'\n\n\ndef state_change(curr_board, from_, to_, in_place=True):\n    '''Updates the board configuration by modifying existing values if in_place is set to True, or creating a new board with updated values if in_place is set to False'''\n    board = curr_board\n    if not in_place:\n        board = copy.deepcopy(curr_board)\n    if is_valid_move(board, from_, to_):\n        board[from_[0]][from_[1]] = '_'\n        board[to_[0]][to_[1]] = 'B'\n    return board\n\n\n# checks if game is over\ndef is_game_over(board):\n    '''Returns True if game is over'''\n    flag = any(board[ROW - 1][i] == 'B' or board[0][i] == 'W' for i in range(COL))\n\n    wcount, bcount = 0, 0\n    for i in range(ROW):\n        for j in range(COL):\n            if board[i][j] == 'B':\n                bcount += 1\n            elif board[i][j] == 'W':\n                wcount += 1\n\n    if wcount == 0 or bcount == 0:\n        flag = True\n\n    return flag\n\n\n#############################################\n# Utils function for game playing framework #\n# ############################################\n\n\n# move making function for game playing\ndef make_move_job_func(player, board, queue):\n    # disable stdout and stderr to prevent prints\n    sys.stdout = open(os.devnull, 'w')\n    sys.stderr = open(os.devnull, 'w')\n    try:\n        src, dst = player.make_move(\n            board\n        )  # returns [i1, j1], [i2, j2] -> pawn moves from position [i1, j1] to [i2, j2]\n        queue.put((src, dst))\n    except KeyboardInterrupt:\n        exit()\n    except Exception as e:\n        queue.put(e)\n        exit(1)\n    finally:\n        # reenable stdout and stderr\n        sys.stdout = sys.__stdout__\n        sys.stderr = sys.__stderr__\n    return\n\n\n# game playing function. Takes in the initial board\ndef play(playerAI_A, playerAI_B, board):\n    COLOURS = [BLACK, WHITE] = 'Black(Student agent)', 'White(Test agent)'\n    TIMEOUT = 3\n    random_moves = 0\n    PLAYERS = []\n    move = 0\n\n    # disable stdout for people who leave print statements in their code, disable stderr\n    old_stdout = sys.stdout\n    old_stderr = sys.stderr\n    sys.stdout = open(os.devnull, 'w')\n    sys.stderr = open(os.devnull, 'w')\n    try:\n        PLAYERS.append(playerAI_A)\n    except KeyboardInterrupt:\n        exit()\n    except:\n        return f'{BLACK} failed to initialise'\n    finally:\n        # reenable stdout and stderr\n        sys.stdout = old_stdout\n        sys.stderr = old_stderr\n\n    # disable stdout for people who leave print statements in their code, disable stderr\n    old_stdout = sys.stdout\n    old_stderr = sys.stderr\n    sys.stdout = open(os.devnull, 'w')\n    sys.stderr = open(os.devnull, 'w')\n    try:\n        PLAYERS.append(playerAI_B)\n    except KeyboardInterrupt:\n        exit()\n    except:\n        return f'{WHITE} failed to initialise'\n    finally:\n        # reenable stdout and stderr\n        sys.stdout = old_stdout\n        sys.stderr = old_stderr\n\n    # game starts\n    while not is_game_over(board):\n        player = PLAYERS[move % 2]\n        colour = COLOURS[move % 2]\n        src, dst = -1, -1\n        if colour == WHITE:\n            invert_board(board)\n            src, dst = player.make_move(board)\n        else:  # BLACK\n            board_copy = copy.deepcopy(board)\n            start_time = time.time()\n            src, dst = player.make_move(board_copy)\n            end_time = time.time()\n\n            isValid = False\n            try:\n                isValid = is_valid_move(board, src, dst) and end_time - start_time <= TIMEOUT\n            except KeyboardInterrupt:\n                exit()\n            except Exception:\n                isValid = False\n            if not isValid:  # if move is invalid or time is exceeded, then we give a random move\n                random_moves += 1\n                src, dst = generate_rand_move(board)\n\n        state_change(board, src, dst)  # makes the move effective on the board\n        if colour == WHITE:\n            invert_board(board)\n        move += 1\n\n    return f'{colour} win; Random move made by {BLACK}: {random_moves};'\n\n\n# decorator for first three public test cases\ndef wrap_test(func):\n    def inner(*args, **kwargs):\n        try:\n            return func(*args, **kwargs)\n        except Exception as e:\n            return f'FAILED, reason: {str(e)}'\n\n    return inner\n\n\nTIME_LIMIT = 3.05\n\n\nclass TimeoutException(Exception):\n    pass\n\n\ndef timeout(timeout):\n    def deco(func):\n        @functools.wraps(func)\n        def wrapper(*args, **kwargs):\n            res = [\n                TimeoutException(\n                    'Function [%s] exceeded timeout of [%s seconds]' % (func.__name__, timeout)\n                )\n            ]\n\n            def newFunc():\n                try:\n                    res[0] = func(*args, **kwargs)\n                except Exception as e:\n                    res[0] = e\n\n            t = Thread(target=newFunc)\n            t.daemon = True\n            try:\n                t.start()\n                t.join(timeout)\n            except Exception as je:\n                print('Error starting thread')\n                raise je\n            ret = res[0]\n            if isinstance(ret, BaseException):\n                raise ret\n            return ret\n\n        return wrapper\n\n    return deco\n\n\n@wrap_test\n@timeout_decorator.timeout(TIME_LIMIT)\ndef test(board, playerAI):\n    board_copy = copy.deepcopy(board)\n    start = time.time()\n    src, dst = playerAI.make_move(board_copy)\n    end = time.time()\n    move_time = end - start\n    valid = is_valid_move(board, src, dst)\n    return valid and move_time <= 3\n\n\n@wrap_test\n@timeout(TIME_LIMIT)\ndef test_windows(board, playerAI):\n    board_copy = copy.deepcopy(board)\n    start = time.time()\n    src, dst = playerAI.make_move(board_copy)\n    end = time.time()\n    move_time = end - start\n    valid = is_valid_move(board, src, dst)\n    return valid and move_time <= 3\n\n\nif os.name == 'nt':\n    test = test_windows\n"
+                  }
+                }
+              ]
+            },
+            {
+              "id": 2,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "generate_init_state",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 3,
+              "type": "OBJECT_ACCESS_STEP",
+              "key": "board",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 4,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "is_game_over",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 5,
+              "type": "LOOP_STEP",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "CONTROL.IN.PREDICATE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "CONTROL.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT.BODY"
+                }
+              ]
+            },
+            {
+              "id": 6,
+              "type": "IF_ELSE_STEP",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "CONTROL.IN.PREDICATE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "CONTROL.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT.IF"
+                },
+                {
+                  "id": "CONTROL.OUT.ELSE"
+                }
+              ]
+            },
+            {
+              "id": 7,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "make_move",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 8,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "state_change_modified",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.STATE"
+                },
+                {
+                  "id": "DATA.IN.ARG.1.MOVE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "CONTROL.OUT"
+                },
+                {
+                  "id": "DATA.OUT"
+                }
+              ]
+            },
+            {
+              "id": 9,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "invert_board",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 10,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "make_move",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 11,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "state_change_modified",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.STATE"
+                },
+                {
+                  "id": "DATA.IN.ARG.1.MOVE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 12,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "invert_board",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 13,
+              "type": "OUTPUT_STEP",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.STATE"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            },
+            {
+              "id": 14,
+              "type": "PY_RUN_FUNCTION_STEP",
+              "function_identifier": "invert_board",
+              "inputs": [
+                {
+                  "id": "CONTROL.IN"
+                },
+                {
+                  "id": "DATA.IN.FILE"
+                },
+                {
+                  "id": "DATA.IN.ARG.0.BOARD"
+                }
+              ],
+              "outputs": [
+                {
+                  "id": "DATA.OUT"
+                },
+                {
+                  "id": "CONTROL.OUT"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -299,9 +299,16 @@ class OutputStep(Step):
     def run(self, var_inputs: dict[SocketName, ProgramVariable], *_) -> Program:
         program: Program = [*self.debug_stmts()]
 
+        program.append("import json")
         result = (
             "{"
-            + ", ".join((f'"{key}": {variable_name}' for key, variable_name in var_inputs.items()))
+            + ", ".join(
+                (
+                    f'"{key}": {variable_name}'
+                    for key, variable_name in var_inputs.items()
+                    if not key.startswith("CONTROL")
+                )
+            )
             + "}"
         )
         program.append(f"print(json.dumps({result}))")

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -221,6 +221,12 @@ class ComputeGraph(Graph[Step]):
 
                 # Find the socket that the link is connected to
                 for socket in filter(lambda socket: socket.id == in_edge.to_socket_id, node.inputs):
+                    # If no sockets are connected to this input socket, skip.
+                    if not list(
+                        filter(lambda socket: socket.id == in_edge.from_socket_id, in_node.outputs)
+                    ):
+                        continue
+
                     # Get origining node socket from in_node
                     in_node_socket: StepSocket = next(
                         filter(lambda socket: socket.id == in_edge.from_socket_id, in_node.outputs)
@@ -267,7 +273,7 @@ class InputStep(Step):
 
         program: Program = [*self.debug_stmts()]
         for output in self.outputs:
-            assert output.data is not None
+            assert output.id.startswith("CONTROL") or output.data is not None
             if isinstance(output.data, File):
                 # If the input is a `File`, we skip the serialization and just pass the file object
                 # directly to the next step. This is handled by the `ComputeGraph` class

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -293,16 +293,24 @@ class StringMatchStep(Step):
 
 
 class ObjectAccessStep(Step):
+    """
+    A step to retrieve a value from a dictionary.
+    To use this step, the user must provide the key value to access the dictionary.
+
+    Socket Name Format:
+    - DATA: for the dictionary
+    """
+
     subgraph_socket_ids: ClassVar[set[str]] = set()
     key: str
 
-    def run(self, var_inputs: dict[SocketName, ProgramVariable], _, __, debug: bool) -> Program:
+    def run(self, var_inputs: dict[SocketName, ProgramVariable], *_) -> Program:
         output_socket_name: str = self.outputs[0].id
 
         # Assumption: input socket id is DATA
         input_value = var_inputs["DATA"]
         return [
-            self.debug_stmt() if debug else "",
+            *self.debug_stmts(),
             f"{self.get_output_variable(output_socket_name)} = {input_value}['{self.key}']",
         ]
 

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -291,7 +291,7 @@ class OutputStep(Step):
     subgraph_socket_ids: ClassVar[set[str]] = set()
 
     @model_validator(mode="after")
-    def check_non_empty_outputs(self) -> Self:
+    def check_non_empty_inputs(self) -> Self:
         if len(self.inputs) == 0:
             raise ValueError("Output step must have at least one input")
 

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -221,9 +221,9 @@ class ComputeGraph(Graph[Step]):
 
                 # Find the socket that the link is connected to
                 for socket in filter(lambda socket: socket.id == in_edge.to_socket_id, node.inputs):
-                    in_node_sockets = list(
-                        filter(lambda socket: socket.id == in_edge.from_socket_id, in_node.outputs)
-                    )
+                    in_node_sockets = [
+                        socket for socket in in_node.outputs if socket.id == in_edge.from_socket_id
+                    ]
                     assert len(in_node_sockets) in (0, 1)
 
                     # If no sockets are connected to this input socket, skip.

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -280,6 +280,29 @@ class InputStep(Step):
         return program
 
 
+class OutputStep(Step):
+    subgraph_socket_ids: ClassVar[set[str]] = set()
+
+    @model_validator(mode="after")
+    def check_non_empty_outputs(self) -> Self:
+        if len(self.inputs) == 0:
+            raise ValueError("Output step must have at least one input")
+
+        return self
+
+    def run(self, var_inputs: dict[SocketName, ProgramVariable], *_) -> Program:
+        program: Program = [*self.debug_stmts()]
+
+        result = (
+            "{"
+            + ", ".join((f'"{key}": {variable_name}' for key, variable_name in var_inputs.items()))
+            + "}"
+        )
+        program.append(f"print(json.dumps({result}))")
+
+        return program
+
+
 class StringMatchStep(Step):
     subgraph_socket_ids: ClassVar[set[str]] = set()
 

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -253,7 +253,7 @@ class InputStep(Step):
             raise ValueError("Input step must have at least one output")
 
         for output in self.outputs:
-            if output.data is None:
+            if output.data is None and not output.id.startswith("CONTROL"):
                 raise ValueError(f"Output socket {output.id} must have data")
 
         return self

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -274,7 +274,6 @@ class InputStep(Step):
 
         program: Program = [*self.debug_stmts()]
         for output in self.outputs:
-            assert output.id.startswith("CONTROL") or output.data is not None
             if isinstance(output.data, File):
                 # If the input is a `File`, we skip the serialization and just pass the file object
                 # directly to the next step. This is handled by the `ComputeGraph` class

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -20,6 +20,7 @@ Program = list[Union["Program", ProgramFragment]]
 
 class StepType(str, Enum):
     PY_RUN_FUNCTION = "PY_RUN_FUNCTION_STEP"
+    OBJECT_ACCESS = "OBJECT_ACCESS_STEP"
 
     # I/O Operations
     INPUT = "INPUT_STEP"
@@ -275,6 +276,21 @@ class StringMatchStep(Step):
         return [
             self.debug_stmt() if debug else "",
             f"{self.get_output_variable(output_socket_name)} = str({var_inputs[self.inputs[0].id]}) == str({var_inputs[self.inputs[1].id]})",
+        ]
+
+
+class ObjectAccessStep(Step):
+    subgraph_socket_ids: ClassVar[set[str]] = set()
+    key: str
+
+    def run(self, var_inputs: dict[SocketName, ProgramVariable], _, __, debug: bool) -> Program:
+        output_socket_name: str = self.outputs[0].id
+
+        # Assumption: input socket id is DATA
+        input_value = var_inputs["DATA"]
+        return [
+            self.debug_stmt() if debug else "",
+            f"{self.get_output_variable(output_socket_name)} = {input_value}['{self.key}']",
         ]
 
 

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -260,7 +260,7 @@ class InputStep(Step):
             raise ValueError("Input step must have at least one output")
 
         for output in self.outputs:
-            if output.data is None and not output.id.startswith("CONTROL"):
+            if output.data is None and not output.type == "CONTROL":
                 raise ValueError(f"Output socket {output.id} must have data")
 
         return self

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -221,16 +221,17 @@ class ComputeGraph(Graph[Step]):
 
                 # Find the socket that the link is connected to
                 for socket in filter(lambda socket: socket.id == in_edge.to_socket_id, node.inputs):
-                    # If no sockets are connected to this input socket, skip.
-                    if not list(
+                    in_node_sockets = list(
                         filter(lambda socket: socket.id == in_edge.from_socket_id, in_node.outputs)
-                    ):
+                    )
+                    assert len(in_node_sockets) in (0, 1)
+
+                    # If no sockets are connected to this input socket, skip.
+                    if not in_node_sockets:
                         continue
 
                     # Get origining node socket from in_node
-                    in_node_socket: StepSocket = next(
-                        filter(lambda socket: socket.id == in_edge.from_socket_id, in_node.outputs)
-                    )
+                    in_node_socket: StepSocket = in_node_sockets[0]
 
                     if in_node_socket.data is not None and isinstance(in_node_socket.data, File):
                         # NOTE: File objects are passed directly to the next step and not serialized as a variable

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -224,7 +224,7 @@ class ComputeGraph(Graph[Step]):
                     in_node_sockets = [
                         socket for socket in in_node.outputs if socket.id == in_edge.from_socket_id
                     ]
-                    assert len(in_node_sockets) in (0, 1)
+                    assert len(in_node_sockets) <= 1
 
                     # If no sockets are connected to this input socket, skip.
                     if not in_node_sockets:


### PR DESCRIPTION
# new steps
1. ObjectAccessNode - to extract field from dictionary
2. OutputStep

# fixes
- removes assumption that all input sockets have something connecting to it

# modification to original utils.py in json file:
1. generate_init_state is now a dictionary including the move
```
def generate_init_state():
    state = [
        ["B"] * COL,
        ["B"] * COL,  # 2 black rows
        ["_"] * COL,
        ["_"] * COL,  # 2 empty rows
        ["W"] * COL,
        ["W"] * COL,  # 2 white rows
    ]
    return {"board": state, "move": "B"}
```
1. adds this function
```
# makes a move effective on the board by modifying board state, or returning a new board with updated board state
def state_change_modified(state, move, in_place=True):
    curr_board = state["board"]

    from_, to_ = move
    """Updates the board configuration by modifying existing values if in_place is set to True, or creating a new board with updated values if in_place is set to False"""
    board = curr_board
    if not in_place:
        board = copy.deepcopy(curr_board)
    if is_valid_move(board, from_, to_):
        board[from_[0]][from_[1]] = "_"
        board[to_[0]][to_[1]] = "B"

    state["board"] = curr_board
    state["move"] = "W" if state["move"] == "B" else "B"
```