### PR TITLE
refactor: validate `Step` input and outputs

### DIFF
--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -306,9 +306,6 @@ class InputStep(Step):
 
     @model_validator(mode="after")
     def check_non_empty_outputs(self) -> Self:
-        if len(self.outputs) == 0:
-            raise ValueError("Input step must have at least one output")
-
         for output in self.outputs:
             if output.data is None and not output.type == "CONTROL":
                 raise ValueError(f"Output socket {output.id} must have data")
@@ -338,13 +335,6 @@ class InputStep(Step):
 
 class OutputStep(Step):
     required_data_io: ClassVar[tuple[Range, Range]] = ((1, -1), (0, 0))
-
-    @model_validator(mode="after")
-    def check_non_empty_inputs(self) -> Self:
-        if len(self.inputs) == 0:
-            raise ValueError("Output step must have at least one input")
-
-        return self
 
     def run(self, var_inputs: dict[SocketName, ProgramVariable], *_) -> Program:
         program: list[Program | str] = [*self.debug_stmts()]
@@ -393,15 +383,6 @@ class ObjectAccessStep(Step):
 
     @model_validator(mode="after")
     def check_has_exactly_one_data_input(self) -> Self:
-        if (
-            num_data_inputs := len(
-                [in_socket for in_socket in self.inputs if in_socket.type == "DATA"]
-            )
-        ) != 1:
-            raise ValueError(
-                f"Object access step ({self.id}) must have exactly one data input, found {num_data_inputs}"
-            )
-
         if "DATA.IN" not in self.in_socket_index:
             raise ValueError(
                 f"Object access step ({self.id}) must have a data input socket with the id DATA.IN"
@@ -430,19 +411,6 @@ class PyRunFunctionStep(Step):
     required_data_io: ClassVar[tuple[Range, Range]] = ((0, -1), (1, 1))
 
     function_identifier: str
-
-    @model_validator(mode="after")
-    def check_has_exactly_one_data_output(self) -> Self:
-        if (
-            num_data_outputs := len(
-                [out_socket for out_socket in self.outputs if out_socket.type == "DATA"]
-            )
-        ) != 1:
-            raise ValueError(
-                f"Py run function step ({self.id}) must have exactly one data output, found {num_data_outputs}"
-            )
-
-        return self
 
     def run(
         self,

--- a/unicon_backend/evaluator/tasks/programming/steps.py
+++ b/unicon_backend/evaluator/tasks/programming/steps.py
@@ -392,7 +392,7 @@ class PyRunFunctionStep(Step):
     - DATA.IN.FILE: For the `File` object that contains the Python function
     """
 
-    required_data_io: ClassVar[tuple[Range, Range]] = ((0, -1), (1, 1))
+    required_data_io: ClassVar[tuple[Range, Range]] = ((1, -1), (1, 1))
 
     _data_in_file_id: ClassVar[str] = "DATA.IN.FILE"
 

--- a/unicon_backend/lib/helpers.py
+++ b/unicon_backend/lib/helpers.py
@@ -1,0 +1,8 @@
+from collections.abc import Callable, Sequence
+
+
+def partition[T](
+    predicate: Callable[[T], bool], xs: Sequence[T]
+) -> tuple[Sequence[T], Sequence[T]]:
+    """Partition a sequence into two sequences based on a predicate"""
+    return [x for x in xs if predicate(x)], [x for x in xs if not predicate(x)]


### PR DESCRIPTION
This PR adds validation rules to the compute graph, verifying that each compute node (or `Step`) adheres to the expected/required number of inputs and output (I/O) sockets.

The expected number of I/O sockets is represented as a range `[min::int, max::int]` (both bounds are inclusive) for each kind of socket (categorised by type and direction). Additionally, there is also support for variable number of I/O using `-1`. For example:

- No constraints: `[-1, -1]` (aka anything goes)
- No limit on maximum but minimum 1: `[1, -1]`
- No limit on minimum but maximum of 3: `[-1, 3]`

Additionally, the socket id format has been relaxed to not include the `DIRECTION` component. We are already differentiating them at the `Step` level with `Step::inputs` and `Step::outputs`. Furthermore, the observation is that it does not influence assembly logic (and it probably shouldn't either) and only serves as an UI/UX artefact for the node graph editor.