### PR TITLE
feat: hoist and remove redundant import statements

### DIFF
--- a/unicon_backend/cli.py
+++ b/unicon_backend/cli.py
@@ -1,9 +1,6 @@
 from typing import Annotated
 
-import libcst as cst
-import libcst.codemod.visitors as codemod
 import typer
-from libcst.codemod import CodemodContext
 from rich.console import Console
 from rich.syntax import Syntax
 from rich.table import Table
@@ -13,40 +10,6 @@ from unicon_backend.models.contest import TaskType
 
 rich_console = Console()
 app = typer.Typer(name="Unicon 🦄 CLI")
-
-
-class RemoveImportsTransformer(cst.CSTTransformer):
-    def leave_Import(self, _, __):
-        return cst.RemoveFromParent()
-
-    def leave_ImportFrom(self, _, __):
-        return cst.RemoveFromParent()
-
-
-class AddImportsTransformer(cst.CSTTransformer):
-    def __init__(self, imports: set[str], import_froms: dict[str, set[str]]) -> None:
-        self._imports = imports
-        self._import_froms = import_froms
-        super().__init__()
-
-    def leave_Module(self, node: cst.Module, _) -> cst.Module:
-        import_stmts = [
-            cst.SimpleStatementLine(
-                [cst.Import([cst.ImportAlias(name=cst.Name(module)) for module in self._imports])]
-            ),
-        ]
-        import_from_stmts = [
-            cst.SimpleStatementLine(
-                [
-                    cst.ImportFrom(
-                        module=cst.Name(module),
-                        names=[cst.ImportAlias(name=cst.Name(obj)) for obj in objs],
-                    )
-                ]
-            )
-            for module, objs in self._import_froms.items()
-        ]
-        return cst.Module(body=[*import_stmts, *import_from_stmts, *node.body])
 
 
 @app.command(name="assemble")
@@ -70,15 +33,8 @@ def assemble(defn_file: Annotated[typer.FileText, typer.Option("--defn", mode="r
         for testcase in task.testcases:
             assembled_prog = testcase.run(user_input_step)
 
-            # TEMP: Proof of concept for import hoisting
-            import_visitor = codemod.GatherImportsVisitor(CodemodContext())
-            assembled_prog.visit(import_visitor)
-            imports, import_froms = import_visitor.module_imports, import_visitor.object_mapping
-            no_imports = assembled_prog.visit(RemoveImportsTransformer())
-            transformed = no_imports.visit(AddImportsTransformer(imports, import_froms))
-
             syntax_highlighted_code = Syntax(
-                transformed.code, "python", theme="material", line_numbers=True, word_wrap=True
+                assembled_prog.code, "python", theme="material", line_numbers=True, word_wrap=True
             )
             table.add_row(str(testcase.id), syntax_highlighted_code)
 

--- a/unicon_backend/evaluator/tasks/programming/transforms.py
+++ b/unicon_backend/evaluator/tasks/programming/transforms.py
@@ -1,0 +1,39 @@
+import libcst as cst
+from libcst.codemod import CodemodContext
+from libcst.codemod.visitors import AddImportsVisitor, GatherImportsVisitor, ImportItem
+
+
+class RemoveImportsVisitors(cst.CSTTransformer):
+    """
+    A visitor that removes all import statements from the code.
+    """
+
+    def leave_Import(self, _og_node: cst.Import, _updated_node: cst.Import) -> cst.RemovalSentinel:
+        return cst.RemoveFromParent()
+
+    def leave_ImportFrom(
+        self, _og_node: cst.ImportFrom, _updated_node: cst.ImportFrom
+    ) -> cst.RemovalSentinel:
+        return cst.RemoveFromParent()
+
+
+def hoist_imports(program: cst.Module) -> cst.Module:
+    """
+    Hoist all import statements to the top of the program. Additionally, it combines and remove imports to
+    prevent duplicate imports.
+    """
+    context = CodemodContext()
+    gather_imports_visitor = GatherImportsVisitor(context)
+    program.visit(gather_imports_visitor)
+    removed_imports = program.visit(RemoveImportsVisitors())
+    add_imports_visitor = AddImportsVisitor(
+        context,
+        [ImportItem(module_name_str) for module_name_str in gather_imports_visitor.module_imports]
+        + [
+            ImportItem(module_name_str, obj_name=obj_name_str)
+            for module_name_str, obj_name_strs in gather_imports_visitor.object_mapping.items()
+            for obj_name_str in obj_name_strs
+        ],
+    )
+    program = removed_imports.visit(add_imports_visitor)
+    return program


### PR DESCRIPTION
Fixes #37 

This PR implements a CST transform to hoist and combine import statements in the assembled program. The logic implemented is a naive one for now where it first (1) gathers all imports, (2) remove all important statements and finally (3) add the combined import statements to the top of the module file. There is definitely not the most optimal implementation and should be refactored in the future. However, in my opinion, this improves the "quality" of the assembled program enough to be merged for now.

Example:

```diff
+ import json
+ from utils import state_change_modified, invert_board, is_game_over, generate_init_state

- from utils import generate_init_state
var_2_DATA_OUT = generate_init_state()
var_3_DATA_OUT = var_2_DATA_OUT['board']
while True:
-  from utils import is_game_over
    var_4_DATA_OUT = is_game_over(var_3_DATA_OUT)
    if var_4_DATA_OUT: break
-  from utils import invert_board
    var_14_DATA_OUT = invert_board(var_3_DATA_OUT)
    if var_14_DATA_OUT:
        var_7_DATA_OUT = call_function_safe(agent_1, make_move, var_3_DATA_OUT)
        from utils import state_change_modified
        var_8_DATA_OUT = state_change_modified(var_2_DATA_OUT, var_7_DATA_OUT)
    else:
-       from utils import invert_board
        var_9_DATA_OUT = invert_board(var_3_DATA_OUT)
        var_10_DATA_OUT = call_function_safe(agent_2, make_move, var_3_DATA_OUT)
-       from utils import state_change_modified
        var_11_DATA_OUT = state_change_modified(var_2_DATA_OUT, var_10_DATA_OUT)
-       from utils import invert_board
        var_12_DATA_OUT = invert_board(var_3_DATA_OUT)
- import json
print(json.dumps({'DATA.STATE': var_2_DATA_OUT}))
```