### PR TITLE
chore: allow runtime flags and args in deploy container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ WORKDIR /unicon-backend
 # Install dependencies
 RUN uv sync --frozen --no-dev
 
-CMD ["uv", "run", "fastapi", "run", "unicon_backend/app.py", "--port", "9000"]
+ENTRYPOINT ["uv", "run", "fastapi", "run", "unicon_backend/app.py"]


### PR DESCRIPTION
This PR adds changes the deploy image to use `ENTRYPOINT` instead of `CMD` to allow for dynamic runtime flags and arguments. This is an added convenience to dynamically set the port of the web server (or `backend`) during deployment.

For now if no args are passed the web server defaults to port `8000`.