### PR TITLE
feat: support seeding problems via `unicon_backend:cli`

### DIFF
--- a/examples/breakthrough/definition.json
+++ b/examples/breakthrough/definition.json
@@ -3,7 +3,7 @@
   "description": "Done with PS3, but want to improve on your AI further?",
   "tasks": [
     {
-      "id": 1,
+      "id": 0,
       "type": "PROGRAMMING_TASK",
       "question": "Breakthrough Match",
       "environment": {

--- a/examples/problem_set/definition.json
+++ b/examples/problem_set/definition.json
@@ -33,7 +33,7 @@
       "question": "Implement Tree Search",
       "environment": {
         "language": "PYTHON",
-        "options": {
+        "extra_options": {
           "version": "3.12"
         },
         "time_limit_secs": 10,


### PR DESCRIPTION
Example usage:

```bash
# Seed all the example definitions
uv run unicon_backend/cli.py seed admin admin \
    ./examples/addition/definitions/*.json \
    ./examples/problem_set/definition.json \
    ./examples/breakthrough/definition.json
```

<img width="491" alt="image" src="https://github.com/user-attachments/assets/99bbcd50-26ba-457d-ab95-5c689acb9bc8" />

> now the user also get a nice summary of seeded data 🤗